### PR TITLE
Add not modified response

### DIFF
--- a/index.js
+++ b/index.js
@@ -139,6 +139,11 @@ JsonResponder.prototype.found = function(url){
   this.res.end();
 };
 
+JsonResponder.prototype.notModified = function(url){
+  this.res.writeHead(304);
+  this.res.end();
+};
+
 JsonResponder.prototype.redirect = function(url){
   this.found(url);
 };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "http",
     "hypermedia"
   ],
-  "version": "0.5.3",
+  "version": "0.5.4",
   "bugs": {
     "url": "https://github.com/cainus/json-status/issues"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -171,6 +171,15 @@ describe("JsonStatus", function(){
       fakeRes.ended.should.equal(true);
     });
   });
+  describe("#notModified", function(){
+    it ("sets the status to 304", function(){
+      var fakeRes = new FakeResponse();
+      var responder = new JsonStatus({}, fakeRes);
+      responder.notModified();
+      fakeRes.status.should.equal(304);
+      fakeRes.ended.should.equal(true);
+    });
+  });
   describe("#OPTIONS", function(){
     it ("sets the Allow header and sets the status to 200", function(){
       var fakeRes = new FakeResponse();


### PR DESCRIPTION
Adds 304 Not Modified, with no response body. Useful for ETag responses.
